### PR TITLE
Make Elixir section name more accurate

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ to be done
 
 - [RubyMotion](http://www.rubymotion.com) - commercial compiler for Apple iOS/Cocoa
 
-## Ruby-to-Erlang
+## Ruby Inspired
 
-- [Elixir](http://elixir-lang.org) - Ruby-inspired syntax; a dynamic, functional language for the Erlang VM compiles to BEAM instructions (bytecode)  
+- [Elixir](http://elixir-lang.org) - Ruby-inspired syntax; a dynamic, functional language for the Erlang VM compiles to BEAM instructions (bytecode)
 
 ## Ruby Version Manager
 


### PR DESCRIPTION
Elixir is not a Ruby-to-Erlang compiler, nor is Elixir like Ruby at all semantically, so the existing header seems inaccurate. Saying it is "Ruby Inspired" would be more fair I think.