### PR TITLE
Nest Fullstaq Ruby under Ruby as it's an alternative distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,9 @@ Find out more @ [Ruby 3x3 - Ruby 3 Will Be 3 Times Faster - What's News? »](htt
 
 ## Major Rubies
 
-- [Ruby](https://www.ruby-lang.org), [:octocat:](https://github.com/ruby) - also known as Matz's Ruby Interpreter (MRI) or CRuby; using the YARV (Yet another Ruby VM) since version 1.9; major releases include: 
-   - 2019: 2.7  (Dec/25th)
-   - 2018: 2.6  (Dec/25th)
-   - 2017: 2.5  (Dec/25th)
-   - 2016: 2.4  (Dec/25th)
-   - 2015: 2.3  (Dec/25th)
-   - 2014: 2.2  (Dec/25th)
-- [Fullstaq Ruby](https://fullstaqruby.org), [:octocat:](https://github.com/fullstaq-labs/fullstaq-ruby-server-edition) - an MRI-based Ruby distribution (fully open source) that's optimized for servers; compiled with the `Jemalloc` and `malloc_trim` patches, allowing lower memory usage and higher performance; by Hongli Lai (Phusion) et al 
-- [JRuby](https://www.jruby.org), [:octocat:](https://github.com/jruby) - Ruby on the Java Virtual Machine (JVM); major releases include:
-   - 2018: v9.2.0.0 (May/24th) - supports Ruby 2.5
-   - 2016: v9.1.0.0 (May/3rd)  - supports Ruby 2.x
-   - 2014: v1.7.x  
+- [Ruby](https://www.ruby-lang.org), [:octocat:](https://github.com/ruby) - also known as Matz's Ruby Interpreter (MRI) or CRuby; using the YARV (Yet another Ruby VM) since version 1.9.
+   - [Fullstaq Ruby](https://fullstaqruby.org), [:octocat:](https://github.com/fullstaq-labs/fullstaq-ruby-server-edition) - an MRI-based Ruby distribution (fully open source) that's optimized for servers; compiled with the `Jemalloc` and `malloc_trim` patches, allowing lower memory usage and higher performance; by Hongli Lai (Phusion) et al 
+- [JRuby](https://www.jruby.org), [:octocat:](https://github.com/jruby) - Ruby on the Java Virtual Machine (JVM)
 - [TruffleRuby :octocat:](https://github.com/oracle/truffleruby) - a high performance Ruby built with the [Truffle Language Kit](https://github.com/oracle/graal/tree/master/truffle) on the GraalVM
 - [mruby](http://www.mruby.org), [:octocat:](https://github.com/mruby) - lightweight Ruby; designed for linking and embedding within your application
   - [mruby/c :octocat:](https://github.com/mrubyc/mrubyc) - alternative mruby designed for one-chip microprocessors and optimized for small size rather than execution speed e.g. memory size < 40 KiB vs. < 400 KiB 


### PR DESCRIPTION
* And not its own Ruby implementation. Similar to mruby/c.
* Remove an explicit list of versions as it's verbose and hard to maintain.